### PR TITLE
add cmake build to Data Atmosphere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(tools)
+add_subdirectory(DATM)

--- a/DATM/CMakeLists.txt
+++ b/DATM/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Data-Atmosphere compiler flags
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+  set(CMAKE_Fortran_FLAGS "-g -fbacktrace -ffree-line-length-none")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow,underflow" )
+  set(CMAKE_Fortran_LINK_FLAGS "")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(CMAKE_Fortran_FLAGS "-g -traceback")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O -assume realloc_lhs")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal -fp-model precise")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -check -check noarg_temp_created -check nopointer -fpe0 -ftrapuv -link_mpi=dbg")
+  set(CMAKE_Fortran_LINK_FLAGS "")
+else()
+  message(WARNING "Fortran compiler with ID ${CMAKE_Fortran_COMPILER_ID} will be used with CMake default options")
+endif()
+
+#list(APPEND _datatm_defs_private coupled)
+
+add_library(datatm STATIC AtmBundleCreate.F90
+                          AtmFieldUtils.F90
+                          AtmForce.F90
+                          AtmGridUtils.F90
+                          AtmInternalFields.F90
+                          AtmModel.F90
+                          LocalDefs.F90
+                          datm.F90)
+
+set_target_properties(datatm PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
+target_include_directories(datatm PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_compile_definitions(datatm PUBLIC "${_datatm_defs_private}")
+target_include_directories(datatm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+                                         $<INSTALL_INTERFACE:mod>)
+target_link_libraries(datatm PUBLIC esmf)
+
+###############################################################################
+### Install
+###############################################################################
+install(
+ TARGETS datatm
+ EXPORT  datatm-config
+ LIBRARY DESTINATION lib
+ ARCHIVE DESTINATION lib
+ COMPONENT Library)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod DESTINATION ${CMAKE_INSTALL_PREFIX}/DATM)
+
+install(EXPORT     datatm-config
+       DESTINATION lib/cmake)

--- a/DATM/datm.F90
+++ b/DATM/datm.F90
@@ -12,7 +12,7 @@ module DAtm
     model_routine_SS            => SetServices, &
     model_label_SetRunClock     => label_SetRunClock, &
     model_label_Advance         => label_Advance
- 
+
   ! Fields exported by Atm
   use AtmFieldUtils,     only : AtmFieldsAdvertise, AtmFieldsRealize
   use AtmFieldUtils,     only : AtmFieldDump
@@ -25,9 +25,9 @@ module DAtm
   use AtmInternalFields
 
   implicit none
-  
+
   private
-  
+
   public SetServices
 
   type(ESMF_VM)   :: vm
@@ -41,20 +41,20 @@ module DAtm
      __FILE__
 
   contains
-  
+
   subroutine SetServices(model, rc)
 
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
-    
+
     rc = ESMF_SUCCESS
-    
+
     ! the NUOPC model component will register the generic methods
     call NUOPC_CompDerive(model, model_routine_SS, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    
+
     ! set entry point for methods that require specific implementation
-    
+
     ! overwrite the default IPDv00 with IPDv02
     call ESMF_GridCompSetEntryPoint(model, &
                                     ESMF_METHOD_INITIALIZE, &
@@ -75,7 +75,7 @@ module DAtm
                                  phaseLabelList=(/"IPDv02p2"/), &
                                  userRoutine=InitializeP2, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    
+
     ! specialize label_SetRunClock which ensures the correct timeStep
     ! is set during the run cycle
     ! -> NUOPC specializes by default --->>> first need to remove the default
@@ -101,7 +101,7 @@ module DAtm
     call ESMF_VMGet(vm,petCount=petCnt,localPet=lPet,rc=rc)
 
   end subroutine SetServices
-  
+
   !-----------------------------------------------------------------------------
 
   subroutine InitializeP0(model, importState, exportState, externalClock, rc)
@@ -177,7 +177,7 @@ module DAtm
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_count
+       read(value, *, iostat=iostat) scalar_field_count
        if (iostat /= 0) then
          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
               msg="DATM : ScalarFieldCount not an integer: "//trim(value), &
@@ -193,7 +193,7 @@ module DAtm
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_idx_grid_nx
+       read(value, *, iostat=iostat) scalar_field_idx_grid_nx
        if (iostat /= 0) then
           call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
                msg="DATM : ScalarFieldIdxGridNX not an integer: "//trim(value), &
@@ -209,7 +209,7 @@ module DAtm
          isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_idx_grid_ny
+       read(value, *, iostat=iostat) scalar_field_idx_grid_ny
        if (iostat /= 0) then
           call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
                msg="DATM : ScalarFieldIdxGridNY not an integer: "//trim(value), &
@@ -228,13 +228,13 @@ module DAtm
   !-----------------------------------------------------------------------------
 
   subroutine InitializeP1(model, importState, exportState, externalClock, rc)
-   
+
     type(ESMF_GridComp)  :: model
     type(ESMF_State)     :: importState
     type(ESMF_State)     :: exportState
     type(ESMF_Clock)     :: externalClock
     integer, intent(out) :: rc
-   
+
     ! local variables
     type(ESMF_Config)       :: cf
     real(ESMF_KIND_R8)      :: medAtmCouplingIntervalSec
@@ -242,7 +242,7 @@ module DAtm
     character(20)           :: cvalue
 
     rc = ESMF_SUCCESS
-   
+
     call ESMF_LogWrite("User initialize routine InitP1 Atm started", ESMF_LOGMSG_INFO)
 
     ! Set up the fields in the AtmBundle
@@ -321,11 +321,11 @@ module DAtm
     call ESMF_LogWrite("User initialize routine InitP1 Atm finished", ESMF_LOGMSG_INFO)
 
   end subroutine InitializeP1
-  
+
   !-----------------------------------------------------------------------------
 
   subroutine InitializeP2(model, importState, exportState, externalClock, rc)
-   
+
     type(ESMF_GridComp)  :: model
     type(ESMF_State)     :: importState
     type(ESMF_State)     :: exportState
@@ -333,7 +333,7 @@ module DAtm
     type(ESMF_Time)      :: currTime
     type(ESMF_VM)        :: vm
     integer, intent(out) :: rc
-    
+
     ! local variables
     type(ESMF_Grid)         :: gridIn
     type(ESMF_Grid)         :: gridOut
@@ -400,7 +400,7 @@ module DAtm
 
     call AtmInit(model, exportState, externalClock, rc)
 
-    ! AtmInit calls AtmForce and loads the values for the first integration 
+    ! AtmInit calls AtmForce and loads the values for the first integration
     ! timestep, so.....
     ! -> set Updated Field Attribute to "true", indicating to the IPDv02p5
     ! generic code to set the timestamp for this Field
@@ -417,7 +417,7 @@ module DAtm
 
       call ESMF_LogWrite(trim(AtmBundleFields(ii)%shortname)//' set to Updated', ESMF_LOGMSG_INFO)
     enddo !ii
-    
+
     ! set scalars for cmeps
     if(len_trim(scalar_field_name) > 0) then
       call State_SetScalar(dble(iatm),scalar_field_idx_grid_nx, exportState, localPet, &
@@ -462,14 +462,14 @@ module DAtm
     call ESMF_LogWrite("User initialize routine InitP2 Atm finished", ESMF_LOGMSG_INFO)
 
   end subroutine InitializeP2
-  
+
   !-----------------------------------------------------------------------------
 
   subroutine ModelAdvance(model, rc)
 
     type(ESMF_GridComp)  :: model
     integer, intent(out) :: rc
-    
+
     ! local variables
     type(ESMF_State)           :: exportState
     type(ESMF_Clock)           :: modelClock
@@ -483,7 +483,7 @@ module DAtm
     character(len=ESMF_MAXSTR) :: export_timestr
 
     rc = ESMF_SUCCESS
-  
+
     call ESMF_LogWrite("User routine ModelAdvance Atm started", ESMF_LOGMSG_INFO)
 
     ! query the Component for its clock and exportState
@@ -493,7 +493,7 @@ module DAtm
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! HERE THE MODEL ADVANCES: currTime -> currTime + timeStep
-    
+
     ! Because of the way that the internal Clock was set by default,
     ! its timeStep is equal to the parent timeStep. As a consequence the
     ! currTime + timeStep is equal to the stopTime of the internal Clock

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,29 @@
+list(APPEND _tools_srcs
+  GFS_diagnostics.F90
+  cdf.F90
+  charstrings.F90
+  fieldmatch.F90
+  find_t850.F90
+  gfstonc_sfc.F90
+  gfstonc_sig.F90
+  kinds.F90
+  param.F90
+  rdnemsio.F90
+  setup_outcdf.F90
+  sfc2nc.F90
+  sfcvars.F90
+  sigma2nc.F90
+  sigmavars.F90
+  tm_secs_from_bc.F90
+  write_sigmacdf.F90)
+
+add_executable(nemsio2nc ${_tools_srcs})
+set_target_properties(nemsio2nc PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod)
+target_include_directories(nemsio2nc PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>)
+target_link_libraries(nemsio2nc PRIVATE nemsio::nemsio)
+target_link_libraries(nemsio2nc PRIVATE w3nco::w3nco_d)
+target_link_libraries(nemsio2nc PRIVATE NetCDF::NetCDF_Fortran)
+
+install(TARGETS nemsio2nc
+        RUNTIME DESTINATION bin
+        COMPONENT Utility)


### PR DESCRIPTION
This PR:
- build's data atmosphere component with cmake.
- fixes a GNU error in `datm.F90`, where a non-negative integer needs to be provided.  This is a similar error we saw in MOM6 nuopc cap.

There is no change in results.